### PR TITLE
Highlight active menu element

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -106,7 +106,7 @@ nav#main-nav div a {
 }
 
 nav#main-nav div a:hover,
-nav#main-nav div a .activeMenu{
+nav#main-nav div a.activeMenu{
     color: red;
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -31,6 +31,12 @@ $(document).ready(function () {
     });
 });
 
+$(".nav-item" ).click(function () {
+    $( ".nav-item" ).removeClass('activeMenu');
+    $(this).addClass('activeMenu');
+});
+
+
 //document.addEventListener('DOMContentLoaded', function () {
 //    document.getElementById('menu-button').addEventListener('click', function () {
 ////        e.stopPropagation();


### PR DESCRIPTION
This PR solves your question regarding  'how to highlight the active menu element'?

As you can imagine, there are always multiple ways to achieve what you are aiming for. 
In this case, I decided for a very simple one: we are using javascript to add / remove the class 'activeMenu' to your navigation item once it is clicked.

Since you have already defined it in your css, I just simply needed to re-use it (and remove one space).
Just have a look at the code. :) 