### PR TITLE
fix language selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,9 +36,9 @@
                 <li class="dropdown nav-item dropdown-main" data-toggle="collapse" data-target=".navbar-collapse">
                     <a class="dropdown-toogle nav-link dropbtn" href="" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Language</a>
                     <div class="dropdown-menu dropdown-content " aria-labelledby="navbarDropdown">
-                        <a class="dropdown-item language-select" href="#">English</a>
-                        <a class="dropdown-item language-select" href="#">Deutsch</a>
-                        <a class="dropdown-item language-select" href="#">Polski</a>
+                        <a class="dropdown-item language-select" href=$('a[href*="#"]:not([href="#"])')>en</a>
+                        <a class="dropdown-item language-select" href=$('a[href*="#"]:not([href="#"])')>de</a>
+                        <a class="dropdown-item language-select" href=$('a[href*="#"]:not([href="#"])')>pl</a>
                     </div>
                 </li>
             </ul>
@@ -197,7 +197,6 @@
     <script src="js/jquery-i18next.min.js"></script>
     <script>
         i18next.init({
-            lng: 'pl',
             lng: 'de',
             fallbackLng: 'en',
             resources: {
@@ -240,9 +239,7 @@
         }, function(err, t) {
             jqueryI18next.init(i18next, $);
             $('.skills').localize();
-            jqueryI18next.init(i18next, $);
             $('.contact').localize();
-            console.log('works');
         });
 
     </script>

--- a/js/main.js
+++ b/js/main.js
@@ -33,9 +33,9 @@ $(document).ready(function () {
     });
 
     $(".language-select").click(function () {
-        e.preventDefault();
-        i18next.changeLanguage = $(this).data('localize');
-        //                $(".language-select").removeClass('i18next.changeLanguage');
-        //                $(this).addClass('i18next.changeLanguage');
+        i18next.changeLanguage(this.innerHTML, function() {
+          $('.skills').localize();
+          $('.contact').localize();
+        });
     });
 });


### PR DESCRIPTION
This PR will make work the language selection via drop down. :)

Some notes

index.html
- href: I changed this from `href="#"` to `href=$('a[href*="#"]:not([href="#"])')` because the first option caused an error in the console. (You can just see it in the developer console.)
- I switched the names inside the tags from "Deutsch" to "de", "English" to "en" and Polski to "pl" -> Why is that? Because our "listener" in the main.js is using "this.innerHTML" - that means, actually what is shown inside your link tags. Since i18next is only aware of languages "de", "en" & "pl" it will only work with that. Now you can think about how to use the "real" language names like you had before with the script. So you need to find a way to transfer the short cuts for the languages to i18next while showing the whole language names to the user.
- In the i18next initialization it is enough to just chose one language as your default language (either pl, de, or en). That's why I deleted one. In the called function it is enough to call the initialization method once. :)